### PR TITLE
fix(attr): change id and key for customInput

### DIFF
--- a/dist/json-reactform.cjs.dev.js
+++ b/dist/json-reactform.cjs.dev.js
@@ -63,7 +63,7 @@ var index = (function (_ref2) {
         type = _model$b.type;
 
     if (type === 'date') {
-      a[b] = defaultValue ? defaultValue.toISOString() : "";
+      a[b] = defaultValue ? defaultValue.toISOString() : '';
     } else if (type === 'select') {
       a[b] = defaultValue ? model[b].options.find(function (option) {
         return option.value === defaultValue;
@@ -192,7 +192,7 @@ var index = (function (_ref2) {
       }, React.createElement(DatePicker, {
         id: key,
         name: key,
-        selected: state[key] ? new Date(state[key]) : "",
+        selected: state[key] ? new Date(state[key]) : '',
         onChange: function onChange(value) {
           return onChangeStateDate(key, value);
         },
@@ -261,8 +261,8 @@ var index = (function (_ref2) {
         return React.createElement(reactstrap.CustomInput, {
           type: "checkbox",
           label: item.label,
-          id: item.value,
-          key: item.value,
+          id: item.label,
+          key: item.label,
           name: key,
           value: item.value,
           checked: state[key].includes(item.value),
@@ -288,8 +288,8 @@ var index = (function (_ref2) {
         return React.createElement(reactstrap.CustomInput, {
           type: "radio",
           label: item.label,
-          id: item.value,
-          key: item.value,
+          id: item.label,
+          key: item.label,
           name: key,
           value: item.value,
           checked: state[key].includes(item.value),

--- a/dist/json-reactform.cjs.prod.js
+++ b/dist/json-reactform.cjs.prod.js
@@ -166,8 +166,8 @@ var index = function(_ref2) {
       return React.createElement(reactstrap.CustomInput, {
         type: "checkbox",
         label: item.label,
-        id: item.value,
-        key: item.value,
+        id: item.label,
+        key: item.label,
         name: key,
         value: item.value,
         checked: state[key].includes(item.value),
@@ -196,8 +196,8 @@ var index = function(_ref2) {
       return React.createElement(reactstrap.CustomInput, {
         type: "radio",
         label: item.label,
-        id: item.value,
-        key: item.value,
+        id: item.label,
+        key: item.label,
         name: key,
         value: item.value,
         checked: state[key].includes(item.value),

--- a/dist/json-reactform.esm.js
+++ b/dist/json-reactform.esm.js
@@ -57,7 +57,7 @@ var index = (function (_ref2) {
         type = _model$b.type;
 
     if (type === 'date') {
-      a[b] = defaultValue ? defaultValue.toISOString() : "";
+      a[b] = defaultValue ? defaultValue.toISOString() : '';
     } else if (type === 'select') {
       a[b] = defaultValue ? model[b].options.find(function (option) {
         return option.value === defaultValue;
@@ -186,7 +186,7 @@ var index = (function (_ref2) {
       }, React.createElement(DatePicker, {
         id: key,
         name: key,
-        selected: state[key] ? new Date(state[key]) : "",
+        selected: state[key] ? new Date(state[key]) : '',
         onChange: function onChange(value) {
           return onChangeStateDate(key, value);
         },
@@ -255,8 +255,8 @@ var index = (function (_ref2) {
         return React.createElement(CustomInput, {
           type: "checkbox",
           label: item.label,
-          id: item.value,
-          key: item.value,
+          id: item.label,
+          key: item.label,
           name: key,
           value: item.value,
           checked: state[key].includes(item.value),
@@ -282,8 +282,8 @@ var index = (function (_ref2) {
         return React.createElement(CustomInput, {
           type: "radio",
           label: item.label,
-          id: item.value,
-          key: item.value,
+          id: item.label,
+          key: item.label,
           name: key,
           value: item.value,
           checked: state[key].includes(item.value),

--- a/src/index.js
+++ b/src/index.js
@@ -10,14 +10,17 @@ import {
   CustomInput,
   Row,
 } from 'reactstrap';
-import DatePicker from "react-datepicker";
-import "react-datepicker/dist/react-datepicker.css";
+import DatePicker from 'react-datepicker';
+import 'react-datepicker/dist/react-datepicker.css';
 import Select from 'react-select';
 import CreatableSelect from 'react-select/creatable';
 import { numberToCurrency, currencyToNumber } from './libs/helper';
 
 const CustomDatePicker = React.forwardRef(
-  ({ onChange, placeholder, value, id, onClick, name, disabled, required }, ref) => {
+  (
+    { onChange, placeholder, value, id, onClick, name, disabled, required },
+    ref
+  ) => {
     return (
       <Input
         ref={ref}
@@ -46,16 +49,14 @@ export default ({ model, onSubmit, onChange }) => {
   const defaultState = Object.keys(model).reduce((a, b) => {
     const { defaultValue, type } = model[b];
     if (type === 'date') {
-      a[b] = defaultValue
-        ? defaultValue.toISOString()
-        : ""
+      a[b] = defaultValue ? defaultValue.toISOString() : '';
     } else if (type === 'select') {
       a[b] = defaultValue
         ? model[b].options.find(option => option.value === defaultValue)
         : '';
     } else if (type === 'checkbox') {
       a[b] = defaultValue && defaultValue.length ? defaultValue : [];
-    } else if(type === 'submit') {
+    } else if (type === 'submit') {
       return a;
     } else {
       a[b] = defaultValue || '';
@@ -78,11 +79,11 @@ export default ({ model, onSubmit, onChange }) => {
     return a;
   }, {});
 
-	const formItems = [];
-	const onFormSubmit = (e) => {
-		e.preventDefault();
-		onSubmit(state);
-	}
+  const formItems = [];
+  const onFormSubmit = e => {
+    e.preventDefault();
+    onSubmit(state);
+  };
 
   const [state, setState] = React.useState(defaultState);
   const [currency, setCurrency] = React.useState(defaultCurrency);
@@ -177,7 +178,7 @@ export default ({ model, onSubmit, onChange }) => {
             <DatePicker
               id={key}
               name={key}
-              selected={state[key] ? new Date(state[key]) : ""}
+              selected={state[key] ? new Date(state[key]) : ''}
               onChange={value => onChangeStateDate(key, value)}
               dateFormat={model[key].format || 'dd-MM-yyyy'}
               customInput={<CustomDatePicker />}
@@ -248,8 +249,8 @@ export default ({ model, onSubmit, onChange }) => {
                 <CustomInput
                   type="checkbox"
                   label={item.label}
-                  id={item.value}
-                  key={item.value}
+                  id={item.label}
+                  key={item.label}
                   name={key}
                   value={item.value}
                   checked={state[key].includes(item.value)}
@@ -278,8 +279,8 @@ export default ({ model, onSubmit, onChange }) => {
                 <CustomInput
                   type="radio"
                   label={item.label}
-                  id={item.value}
-                  key={item.value}
+                  id={item.label}
+                  key={item.label}
                   name={key}
                   value={item.value}
                   checked={state[key].includes(item.value)}
@@ -350,29 +351,26 @@ export default ({ model, onSubmit, onChange }) => {
     }
   });
 
-	React.useEffect(()=>{
-		if(onChange) {
-			const changedObject = [];
-			if(prevState && Object.keys(prevState).length>0){
-				Object.keys(prevState).forEach((key) => {
-					if(prevState[key]!==state[key]){
-						changedObject.push(key);
-					}
-				})
-				onChange({
-					value: state,
-					changed: changedObject
-				});
-			}
-		}
-	}, [state])
+  React.useEffect(() => {
+    if (onChange) {
+      const changedObject = [];
+      if (prevState && Object.keys(prevState).length > 0) {
+        Object.keys(prevState).forEach(key => {
+          if (prevState[key] !== state[key]) {
+            changedObject.push(key);
+          }
+        });
+        onChange({
+          value: state,
+          changed: changedObject,
+        });
+      }
+    }
+  }, [state]);
 
-
-	return (
-		<>
-			<Form onSubmit={onFormSubmit}>
-				{formItems}
-			</Form>
-		</>
-	)
-}
+  return (
+    <>
+      <Form onSubmit={onFormSubmit}>{formItems}</Form>
+    </>
+  );
+};


### PR DESCRIPTION
#Why 
For input type radio and checkbox, sometimes we want the value to be boolean (`true | false`). 
In previous version, we use option.value to be the `key` and `id`. Meanwhile `id` attribute in input can't accept boolean. 

#What 
I change `key` and `id` attribute to accept options.label, which we can assume to always be string. Because label is string that will be printed on screen. 