### PR TITLE
fix: autocomplete off on type date and make it opsional on type text …

### DIFF
--- a/dist/json-reactform.cjs.dev.js
+++ b/dist/json-reactform.cjs.dev.js
@@ -41,7 +41,8 @@ var CustomDatePicker = React.forwardRef(function (_ref, ref) {
     name: name,
     onClick: onClick,
     disabled: disabled,
-    required: required
+    required: required,
+    autoComplete: "off"
   });
 });
 
@@ -317,7 +318,8 @@ var index = (function (_ref2) {
         id: key,
         required: model[key].required,
         disabled: model[key].disabled,
-        placeholder: model[key].placeholder
+        placeholder: model[key].placeholder,
+        autoComplete: "off"
       }))));
     } else if (model[key].type === 'submit') {
       formItems.push(React.createElement(reactstrap.Row, {
@@ -351,7 +353,8 @@ var index = (function (_ref2) {
         id: key,
         required: model[key].required,
         disabled: model[key].disabled,
-        placeholder: model[key].placeholder
+        placeholder: model[key].placeholder,
+        autoComplete: model[key].autoComplete ? '' : 'off'
       }))));
     }
   });

--- a/dist/json-reactform.cjs.prod.js
+++ b/dist/json-reactform.cjs.prod.js
@@ -43,7 +43,8 @@ var CustomDatePicker = React.forwardRef((function(_ref, ref) {
     name: name,
     onClick: onClick,
     disabled: disabled,
-    required: required
+    required: required,
+    autoComplete: "off"
   });
 }));
 
@@ -223,7 +224,8 @@ var index = function(_ref2) {
       id: key,
       required: model[key].required,
       disabled: model[key].disabled,
-      placeholder: model[key].placeholder
+      placeholder: model[key].placeholder,
+      autoComplete: "off"
     })))) : "submit" === model[key].type ? formItems.push(React.createElement(reactstrap.Row, {
       key: key,
       className: "mb-4"
@@ -253,7 +255,8 @@ var index = function(_ref2) {
       id: key,
       required: model[key].required,
       disabled: model[key].disabled,
-      placeholder: model[key].placeholder
+      placeholder: model[key].placeholder,
+      autoComplete: model[key].autoComplete ? "" : "off"
     }))));
   })), React.useEffect((function() {
     if (onChange) {

--- a/dist/json-reactform.esm.js
+++ b/dist/json-reactform.esm.js
@@ -35,7 +35,8 @@ var CustomDatePicker = React.forwardRef(function (_ref, ref) {
     name: name,
     onClick: onClick,
     disabled: disabled,
-    required: required
+    required: required,
+    autoComplete: "off"
   });
 });
 
@@ -311,7 +312,8 @@ var index = (function (_ref2) {
         id: key,
         required: model[key].required,
         disabled: model[key].disabled,
-        placeholder: model[key].placeholder
+        placeholder: model[key].placeholder,
+        autoComplete: "off"
       }))));
     } else if (model[key].type === 'submit') {
       formItems.push(React.createElement(Row, {
@@ -345,7 +347,8 @@ var index = (function (_ref2) {
         id: key,
         required: model[key].required,
         disabled: model[key].disabled,
-        placeholder: model[key].placeholder
+        placeholder: model[key].placeholder,
+        autoComplete: model[key].autoComplete ? '' : 'off'
       }))));
     }
   });

--- a/src/index.js
+++ b/src/index.js
@@ -32,6 +32,7 @@ const CustomDatePicker = React.forwardRef(
         onClick={onClick}
         disabled={disabled}
         required={required}
+        autoComplete="off"
       />
     );
   }
@@ -309,6 +310,7 @@ export default ({ model, onSubmit, onChange }) => {
               required={model[key].required}
               disabled={model[key].disabled}
               placeholder={model[key].placeholder}
+              autoComplete="off"
             />
           </Col>
         </FormGroup>
@@ -344,6 +346,7 @@ export default ({ model, onSubmit, onChange }) => {
               required={model[key].required}
               disabled={model[key].disabled}
               placeholder={model[key].placeholder}
+              autoComplete={model[key].autoComplete ? '' : 'off'}
             />
           </Col>
         </FormGroup>


### PR DESCRIPTION
### What
Make autoComplete 'off' as default and can't be changed, except for input type 'text' or 'number' it will be optional through props `autoComplete={true || false}`.

### Why 
Because, the autoComplete has blocked the user to pick a date on input type `date`.