### PR TITLE
automate versioning and publishing to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "module": "dist/json-reactform.esm.js",
   "scripts": {
     "build": "preconstruct build",
+    "preversion": "git stash; git checkout master; git pull origin master",
+    "postversion": "yarn release",
+    "postpublish": "git push origin --all; git push origin --tags",
     "release": "yarn build && yarn publish",
     "format": "prettier --write ./**/*"
   },


### PR DESCRIPTION
We add this into scripts 
```
"scripts": {
    "build": "preconstruct build",
    "preversion": "git stash; git checkout master; git pull origin master",
    "postversion": "yarn release",
    "postpublish": "git push origin --all; git push origin --tags",
    "release": "yarn build && yarn publish",
    "format": "prettier --write ./**/*"
  },
```

So, to publish new version into `npm registry` we only need to run this on our local repos, 
- `yarn version` or,
- `yarn version --major` or,
- `yarn version --minor` or,
- `yarn version --major`

Then it will automate update `version` in package.json, and update tag in git, publish to npm registry, and push into github. Hope so 🙏🏻